### PR TITLE
Fix Nunjucks dump filter usage to match documentation

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -37,7 +37,7 @@
 		<script type="module">{% include "node_modules/@zachleat/heading-anchors/heading-anchors.js" %}</script>
 
 		{# Add schema.org structured data as JSON-LD #}
-		<script eleventy:ignore type="application/ld+json">{{ schemaorg | dump(\t) | safe }}</script>
+		<script eleventy:ignore type="application/ld+json">{{ schemaorg | dump('\t') | safe }}</script>
 		{# Add schema.org breadcrumb as JSON-LD #}
 		{%- set breadcrumb = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { allowMissing: true, includeSelf: true } ) %}
 
@@ -47,7 +47,7 @@
             {%- set bb = { key: b.key, title: b.title, url: absolutePostUrl, pluginType: b.pluginType } %}
             {%- set breadcrumbSchema = (breadcrumbSchema.push(bb), breadcrumbSchema) %}
         {% endfor %}
-		<script eleventy:ignore type="application/ld+json">{{ breadcrumbSchema | eleventyNavigationToSchemaOrg | dump(\t) | safe }}</script>
+		<script eleventy:ignore type="application/ld+json">{{ breadcrumbSchema | eleventyNavigationToSchemaOrg | dump('\t') | safe }}</script>
 
 	</head> 
 	<body>

--- a/content/blog/adding_breadcrumbs_with_schema/adding_breadcrumbs_with_schema.md
+++ b/content/blog/adding_breadcrumbs_with_schema/adding_breadcrumbs_with_schema.md
@@ -156,7 +156,7 @@ We will generate our breadcrumbs based on the navigation hierary we built with e
     {%- set bb = { key: b.key, title: b.title, url: absolutePostUrl, pluginType: b.pluginType } %}
     {%- set breadcrumbSchema = (breadcrumbSchema.push(bb), breadcrumbSchema) %}
 {% endfor %}
-<script eleventy:ignore type="application/ld+json">{{ breadcrumbSchema | eleventyNavigationToSchemaOrg | dump(\t) | safe }}</script>
+<script eleventy:ignore type="application/ld+json">{{ breadcrumbSchema | eleventyNavigationToSchemaOrg | dump('\t') | safe }}</script>
 ```
 {% endraw %}
 

--- a/content/blog/adding_global_schema_to_eleventy.md
+++ b/content/blog/adding_global_schema_to_eleventy.md
@@ -111,7 +111,7 @@ If we build the schema graph with simple front matter, we can dump it as JSON in
 {% raw %}
 ```html
 {# Add schema.org structured data as JSON-LD #}
-<script eleventy:ignore type="application/ld+json">{{ schemaorg | dump(\t) | safe }}</script>
+<script eleventy:ignore type="application/ld+json">{{ schemaorg | dump('\t') | safe }}</script>
 ```
 {% endraw %}
 


### PR DESCRIPTION
Replaces `| dump(\t)` with `| dump('\t')` to pass the tab character as a string, per the Nunjucks docs: https://mozilla.github.io/nunjucks/templating.html#dump